### PR TITLE
Update refile-mongoid.gemspec

### DIFF
--- a/refile-mongoid.gemspec
+++ b/refile-mongoid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "refile", "~> 0.5"
-  spec.add_runtime_dependency "mongoid", "~> 4.0"
+  spec.add_runtime_dependency "mongoid", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Changed mongoid dependency version specification to ">= 4.0" to make the gem work with the new version of Mongoid (5.0.0.beta).

I tried it on my project and it seems to be working just fine.

Related to issue https://github.com/DimaSamodurov/refile-mongoid/issues/1
