### PR TITLE
Require the whole mongoid file to avoid missing dependencies.

### DIFF
--- a/lib/refile/mongoid.rb
+++ b/lib/refile/mongoid.rb
@@ -1,4 +1,4 @@
 require "refile"
-require "mongoid/document"
+require "mongoid"
 require "refile/mongoid/version"
 require "refile/attachment/mongoid"


### PR DESCRIPTION
With

``` ruby
require "mongoid/document"
```

I have a missing dependency (uninitialized constant BSON (NameError)). I'm with mongoid 5.0.0.
